### PR TITLE
Fix CI and Render production config; add search, filters and auth

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: "3.11"
       - name: Install linter
         run: |
           python -m pip install --upgrade pip
@@ -29,14 +29,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.10, 3.11, 3.12]
+        # Версии обязательно в кавычках: без них YAML читает 3.10 как число 3.1.
+        python-version: ["3.10", "3.11", "3.12"]
     env:
-      DJANGO_SETTINGS_MODULE: corp_site.settings
       SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip
@@ -51,6 +51,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt --no-cache-dir
       - name: Check Django configuration
+        working-directory: corp_site
         run: python manage.py check
       - name: Run tests
+        working-directory: corp_site
         run: python manage.py test

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ db.sqlite3
 # IDE
 .vscode/
 .idea/
+
+# Static build artifacts
+staticfiles/

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@
 
 Домен `*.onrender.com` подхватывается автоматически (через `RENDER_EXTERNAL_HOSTNAME`), отдельно настраивать `ALLOWED_HOSTS` и `CSRF_TRUSTED_ORIGINS` не нужно.
 
+### Администратор на проде
+
+Редактирование и удаление заявок доступны только залогиненным пользователям. Чтобы создать администратора на Render, добавьте в переменные окружения сервиса `DJANGO_SUPERUSER_USERNAME`, `DJANGO_SUPERUSER_PASSWORD` (и опционально `DJANGO_SUPERUSER_EMAIL`) — пользователь создастся автоматически при следующем деплое. Локально: `python manage.py createsuperuser`.
+
 ## Частые проблемы
 
 - Ошибка `ModuleNotFoundError: No module named 'django'` означает, что зависимости не установлены. Проверьте, что из корня репозитория выполнили `pip install -r requirements.txt` и активировали виртуальное окружение.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@
 - Запуск dev-сервера: `python manage.py runserver`.
 - Запуск тестов: `python manage.py test`.
 
+## Деплой на Render
+
+Проект деплоится по Blueprint из `render.yaml`. Важно про базу данных:
+
+- Без переменной `DATABASE_URL` используется SQLite на диске контейнера. На Render диск **эфемерный** — данные стираются при каждом деплое и рестарте.
+- Чтобы данные сохранялись, создайте бесплатный Postgres (например, [Neon](https://neon.tech) или [Supabase](https://supabase.com)) и добавьте `DATABASE_URL` в переменные окружения сервиса в дашборде Render, например: `postgresql://user:password@host/dbname`.
+
+Домен `*.onrender.com` подхватывается автоматически (через `RENDER_EXTERNAL_HOSTNAME`), отдельно настраивать `ALLOWED_HOSTS` и `CSRF_TRUSTED_ORIGINS` не нужно.
+
 ## Частые проблемы
 
 - Ошибка `ModuleNotFoundError: No module named 'django'` означает, что зависимости не установлены. Проверьте, что из корня репозитория выполнили `pip install -r requirements.txt` и активировали виртуальное окружение.

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -6,3 +6,10 @@ pip install -r requirements.txt
 cd corp_site
 python manage.py collectstatic --no-input
 python manage.py migrate
+
+# Создаём администратора, если заданы DJANGO_SUPERUSER_USERNAME и
+# DJANGO_SUPERUSER_PASSWORD (createsuperuser --noinput читает их сам).
+# Повторный запуск не падает: существующий пользователь просто пропускается.
+if [[ -n "${DJANGO_SUPERUSER_USERNAME:-}" && -n "${DJANGO_SUPERUSER_PASSWORD:-}" ]]; then
+  python manage.py createsuperuser --noinput || true
+fi

--- a/corp_site/corp_site/settings.py
+++ b/corp_site/corp_site/settings.py
@@ -1,17 +1,42 @@
 import os
 from pathlib import Path
 
+import dj_database_url
+from django.core.exceptions import ImproperlyConfigured
+
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# Render автоматически задаёт RENDER=true, поэтому на проде DEBUG
+# по умолчанию выключен, а локально разработка работает без настройки.
+IS_RENDER = 'RENDER' in os.environ
 
-SECRET_KEY = os.environ.get(
-    'SECRET_KEY',
-    'django-insecure-0akmnmx&v2%w2%1kl^+y4i5(!m_u^n*g)6t5efi8y6i4uaetmw',
-)
+DEBUG = os.environ.get('DEBUG', 'False' if IS_RENDER else 'True').lower() in ('true', '1', 'yes')
 
-DEBUG = os.environ.get('DEBUG', 'True').lower() in ('true', '1', 'yes')
+SECRET_KEY = os.environ.get('SECRET_KEY')
+if not SECRET_KEY:
+    if DEBUG:
+        SECRET_KEY = 'django-insecure-0akmnmx&v2%w2%1kl^+y4i5(!m_u^n*g)6t5efi8y6i4uaetmw'
+    else:
+        raise ImproperlyConfigured('SECRET_KEY обязателен, когда DEBUG выключен.')
 
-ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '127.0.0.1,localhost').split(',')
+ALLOWED_HOSTS = [h for h in os.environ.get('ALLOWED_HOSTS', '127.0.0.1,localhost').split(',') if h]
+
+CSRF_TRUSTED_ORIGINS = [o for o in os.environ.get('CSRF_TRUSTED_ORIGINS', '').split(',') if o]
+
+# Render передаёт внешний домен сервиса — добавляем его автоматически.
+RENDER_EXTERNAL_HOSTNAME = os.environ.get('RENDER_EXTERNAL_HOSTNAME')
+if RENDER_EXTERNAL_HOSTNAME:
+    ALLOWED_HOSTS.append(RENDER_EXTERNAL_HOSTNAME)
+    CSRF_TRUSTED_ORIGINS.append(f'https://{RENDER_EXTERNAL_HOSTNAME}')
+
+# За прокси Render запросы приходят по HTTP с заголовком X-Forwarded-Proto.
+# Без этой настройки Django считает соединение незащищённым и отклоняет
+# все POST-формы с ошибкой 403 CSRF.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+if not DEBUG:
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
 
 
 # Application definition
@@ -60,12 +85,14 @@ TEMPLATES = [
 WSGI_APPLICATION = 'corp_site.wsgi.application'
 
 
-# Database — пока используем SQLite, чтобы всё работало без Docker
+# Database. Локально — SQLite; на проде задайте DATABASE_URL
+# (например, Postgres от Neon/Supabase), иначе на Render данные
+# будут стираться при каждом деплое из-за эфемерного диска.
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
-    }
+    'default': dj_database_url.config(
+        default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}",
+        conn_max_age=600,
+    )
 }
 
 

--- a/corp_site/corp_site/settings.py
+++ b/corp_site/corp_site/settings.py
@@ -133,5 +133,11 @@ STORAGES = {
 }
 
 
+# Auth
+LOGIN_URL = 'login'
+LOGIN_REDIRECT_URL = 'ticket_list'
+LOGOUT_REDIRECT_URL = 'ticket_list'
+
+
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 

--- a/corp_site/corp_site/urls.py
+++ b/corp_site/corp_site/urls.py
@@ -22,6 +22,7 @@ from django.views.generic import RedirectView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("accounts/", include("django.contrib.auth.urls")),
     path("tickets/", include("tickets.urls")),
     path("", RedirectView.as_view(url="tickets/")),
 ]

--- a/corp_site/templates/base.html
+++ b/corp_site/templates/base.html
@@ -10,6 +10,17 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
         <div class="container">
             <a class="navbar-brand" href="{% url 'ticket_list' %}">Corp Site</a>
+            <div class="d-flex align-items-center gap-2">
+                {% if user.is_authenticated %}
+                <span class="navbar-text">{{ user.username }}</span>
+                <form method="post" action="{% url 'logout' %}" class="d-flex m-0">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-outline-light btn-sm">Выйти</button>
+                </form>
+                {% else %}
+                <a class="btn btn-outline-light btn-sm" href="{% url 'login' %}">Войти</a>
+                {% endif %}
+            </div>
         </div>
     </nav>
     <div class="container">

--- a/corp_site/templates/base.html
+++ b/corp_site/templates/base.html
@@ -13,8 +13,17 @@
         </div>
     </nav>
     <div class="container">
+        {% if messages %}
+        {% for message in messages %}
+        <div class="alert alert-{{ message.tags }} alert-dismissible fade show" role="alert">
+            {{ message }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Закрыть"></button>
+        </div>
+        {% endfor %}
+        {% endif %}
         {% block content %}
         {% endblock %}
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/corp_site/templates/registration/login.html
+++ b/corp_site/templates/registration/login.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block title %}Вход{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-5">
+        <h1>Вход</h1>
+        {% if form.non_field_errors %}
+        <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+        {% endif %}
+        <form method="post">
+            {% csrf_token %}
+            <div class="mb-3">
+                <label class="form-label" for="{{ form.username.id_for_label }}">Логин</label>
+                <input type="text" name="username" id="{{ form.username.id_for_label }}"
+                       class="form-control" value="{{ form.username.value|default:'' }}" autofocus>
+            </div>
+            <div class="mb-3">
+                <label class="form-label" for="{{ form.password.id_for_label }}">Пароль</label>
+                <input type="password" name="password" id="{{ form.password.id_for_label }}"
+                       class="form-control">
+            </div>
+            <input type="hidden" name="next" value="{{ next }}">
+            <button type="submit" class="btn btn-primary">Войти</button>
+            <a href="{% url 'ticket_list' %}" class="btn btn-link">Назад к заявкам</a>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/corp_site/templates/tickets/ticket_detail.html
+++ b/corp_site/templates/tickets/ticket_detail.html
@@ -3,10 +3,12 @@
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1>{{ ticket.title }}</h1>
+    {% if user.is_authenticated %}
     <div>
         <a href="{% url 'ticket_update' ticket.pk %}" class="btn btn-outline-primary btn-sm">Редактировать</a>
         <a href="{% url 'ticket_delete' ticket.pk %}" class="btn btn-outline-danger btn-sm">Удалить</a>
     </div>
+    {% endif %}
 </div>
 
 <div class="card mb-4">

--- a/corp_site/templates/tickets/ticket_detail.html
+++ b/corp_site/templates/tickets/ticket_detail.html
@@ -15,23 +15,11 @@
         <div class="row">
             <div class="col-md-4">
                 <strong>Статус:</strong>
-                {% if ticket.status == 'new' %}
-                <span class="badge bg-primary">{{ ticket.get_status_display }}</span>
-                {% elif ticket.status == 'in_progress' %}
-                <span class="badge bg-warning text-dark">{{ ticket.get_status_display }}</span>
-                {% else %}
-                <span class="badge bg-success">{{ ticket.get_status_display }}</span>
-                {% endif %}
+                <span class="badge {{ ticket.status_badge_class }}">{{ ticket.get_status_display }}</span>
             </div>
             <div class="col-md-4">
                 <strong>Приоритет:</strong>
-                {% if ticket.priority == 3 %}
-                <span class="badge bg-danger">{{ ticket.get_priority_display }}</span>
-                {% elif ticket.priority == 2 %}
-                <span class="badge bg-warning text-dark">{{ ticket.get_priority_display }}</span>
-                {% else %}
-                <span class="badge bg-secondary">{{ ticket.get_priority_display }}</span>
-                {% endif %}
+                <span class="badge {{ ticket.priority_badge_class }}">{{ ticket.get_priority_display }}</span>
             </div>
             <div class="col-md-4">
                 <strong>Крайний срок:</strong> {% if ticket.due_date %}{{ ticket.due_date|date:"d.m.Y" }}{% else %}&mdash;{% endif %}

--- a/corp_site/templates/tickets/ticket_list.html
+++ b/corp_site/templates/tickets/ticket_list.html
@@ -21,22 +21,10 @@
             <tr>
                 <td><a href="{% url 'ticket_detail' ticket.pk %}">{{ ticket.title }}</a></td>
                 <td>
-                    {% if ticket.status == 'new' %}
-                    <span class="badge bg-primary">{{ ticket.get_status_display }}</span>
-                    {% elif ticket.status == 'in_progress' %}
-                    <span class="badge bg-warning text-dark">{{ ticket.get_status_display }}</span>
-                    {% else %}
-                    <span class="badge bg-success">{{ ticket.get_status_display }}</span>
-                    {% endif %}
+                    <span class="badge {{ ticket.status_badge_class }}">{{ ticket.get_status_display }}</span>
                 </td>
                 <td>
-                    {% if ticket.priority == 3 %}
-                    <span class="badge bg-danger">{{ ticket.get_priority_display }}</span>
-                    {% elif ticket.priority == 2 %}
-                    <span class="badge bg-warning text-dark">{{ ticket.get_priority_display }}</span>
-                    {% else %}
-                    <span class="badge bg-secondary">{{ ticket.get_priority_display }}</span>
-                    {% endif %}
+                    <span class="badge {{ ticket.priority_badge_class }}">{{ ticket.get_priority_display }}</span>
                 </td>
                 <td>{% if ticket.due_date %}{{ ticket.due_date|date:"d.m.Y" }}{% else %}&mdash;{% endif %}</td>
             </tr>

--- a/corp_site/templates/tickets/ticket_list.html
+++ b/corp_site/templates/tickets/ticket_list.html
@@ -5,6 +5,31 @@
     <h1>Заявки</h1>
     <a href="{% url 'ticket_create' %}" class="btn btn-success">Создать заявку</a>
 </div>
+<form method="get" class="row g-2 mb-3">
+    <div class="col-md-5">
+        <input type="text" name="q" value="{{ search_query }}" class="form-control"
+               placeholder="Поиск по заголовку и описанию">
+    </div>
+    <div class="col-md-3">
+        <select name="status" class="form-select">
+            <option value="">Все статусы</option>
+            {% for value, label in status_choices %}
+            <option value="{{ value }}" {% if status_filter == value %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-md-2">
+        <select name="priority" class="form-select">
+            <option value="">Любой приоритет</option>
+            {% for value, label in priority_choices %}
+            <option value="{{ value }}" {% if priority_filter == value|stringformat:"s" %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-md-2 d-grid">
+        <button type="submit" class="btn btn-outline-primary">Найти</button>
+    </div>
+</form>
 {% if tickets %}
 <div class="table-responsive">
     <table class="table table-striped">
@@ -36,20 +61,24 @@
 <nav>
     <ul class="pagination justify-content-center">
         {% if page_obj.has_previous %}
-        <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Назад</a></li>
+        <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}{% if querystring %}&amp;{{ querystring }}{% endif %}">Назад</a></li>
         {% endif %}
         {% for num in page_obj.paginator.page_range %}
         <li class="page-item {% if page_obj.number == num %}active{% endif %}">
-            <a class="page-link" href="?page={{ num }}">{{ num }}</a>
+            <a class="page-link" href="?page={{ num }}{% if querystring %}&amp;{{ querystring }}{% endif %}">{{ num }}</a>
         </li>
         {% endfor %}
         {% if page_obj.has_next %}
-        <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Вперед</a></li>
+        <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}{% if querystring %}&amp;{{ querystring }}{% endif %}">Вперед</a></li>
         {% endif %}
     </ul>
 </nav>
 {% endif %}
 {% else %}
+{% if search_query or status_filter or priority_filter %}
+<p class="text-muted">По вашему запросу ничего не найдено</p>
+{% else %}
 <p class="text-muted">Заявок пока нет</p>
+{% endif %}
 {% endif %}
 {% endblock %}

--- a/corp_site/tickets/models.py
+++ b/corp_site/tickets/models.py
@@ -41,6 +41,22 @@ class Ticket(models.Model):
     def get_absolute_url(self):
         return reverse('ticket_detail', kwargs={'pk': self.pk})
 
+    @property
+    def status_badge_class(self) -> str:
+        return {
+            self.Status.NEW: 'bg-primary',
+            self.Status.IN_PROGRESS: 'bg-warning text-dark',
+            self.Status.DONE: 'bg-success',
+        }.get(self.status, 'bg-secondary')
+
+    @property
+    def priority_badge_class(self) -> str:
+        return {
+            self.Priority.HIGH: 'bg-danger',
+            self.Priority.MEDIUM: 'bg-warning text-dark',
+            self.Priority.LOW: 'bg-secondary',
+        }.get(self.priority, 'bg-secondary')
+
 
 class Comment(models.Model):
     ticket = models.ForeignKey(

--- a/corp_site/tickets/tests/test_views.py
+++ b/corp_site/tickets/tests/test_views.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
 
@@ -100,12 +101,62 @@ class TicketCreateViewTests(TestCase):
         self.assertContains(response, "Обязательное поле")
 
 
+class TicketListFilterTests(TestCase):
+    def setUp(self):
+        self.printer = Ticket.objects.create(
+            title="Сломан принтер",
+            description="Не печатает",
+            status=Ticket.Status.NEW,
+            priority=Ticket.Priority.HIGH,
+        )
+        self.internet = Ticket.objects.create(
+            title="Нет интернета",
+            description="Второй этаж без сети",
+            status=Ticket.Status.IN_PROGRESS,
+            priority=Ticket.Priority.LOW,
+        )
+
+    def test_search_by_title(self):
+        response = self.client.get(reverse("ticket_list"), {"q": "принтер"})
+        self.assertContains(response, self.printer.title)
+        self.assertNotContains(response, self.internet.title)
+
+    def test_search_by_description(self):
+        # Регистр совпадает с описанием: SQLite сравнивает кириллицу
+        # в LIKE с учётом регистра (на Postgres поиск регистронезависимый).
+        response = self.client.get(reverse("ticket_list"), {"q": "Второй этаж"})
+        self.assertContains(response, self.internet.title)
+        self.assertNotContains(response, self.printer.title)
+
+    def test_filter_by_status(self):
+        response = self.client.get(reverse("ticket_list"), {"status": "in_progress"})
+        self.assertContains(response, self.internet.title)
+        self.assertNotContains(response, self.printer.title)
+
+    def test_filter_by_priority(self):
+        response = self.client.get(reverse("ticket_list"), {"priority": "3"})
+        self.assertContains(response, self.printer.title)
+        self.assertNotContains(response, self.internet.title)
+
+    def test_no_results_message(self):
+        response = self.client.get(reverse("ticket_list"), {"q": "несуществующее"})
+        self.assertContains(response, "По вашему запросу ничего не найдено")
+
+
 class TicketUpdateViewTests(TestCase):
     def setUp(self):
         self.ticket = Ticket.objects.create(
             title="Старое название",
             description="Описание",
         )
+        self.user = User.objects.create_user("employee", password="test-pass-123")
+        self.client.force_login(self.user)
+
+    def test_anonymous_redirected_to_login(self):
+        self.client.logout()
+        url = reverse("ticket_update", args=[self.ticket.pk])
+        response = self.client.get(url)
+        self.assertRedirects(response, f"{reverse('login')}?next={url}")
 
     def test_update_ticket(self):
         data = {
@@ -129,6 +180,15 @@ class TicketDeleteViewTests(TestCase):
             title="Удалить меня",
             description="Описание",
         )
+        self.user = User.objects.create_user("employee", password="test-pass-123")
+        self.client.force_login(self.user)
+
+    def test_anonymous_redirected_to_login(self):
+        self.client.logout()
+        url = reverse("ticket_delete", args=[self.ticket.pk])
+        response = self.client.post(url)
+        self.assertRedirects(response, f"{reverse('login')}?next={url}")
+        self.assertEqual(Ticket.objects.count(), 1)
 
     def test_delete_ticket(self):
         response = self.client.post(

--- a/corp_site/tickets/tests/test_views.py
+++ b/corp_site/tickets/tests/test_views.py
@@ -83,6 +83,22 @@ class TicketCreateViewTests(TestCase):
         self.assertEqual(ticket.title, "Новая заявка")
         self.assertRedirects(response, reverse("ticket_detail", args=[ticket.pk]))
 
+    def test_create_ticket_shows_success_message(self):
+        data = {
+            "title": "Новая заявка",
+            "description": "Описание заявки",
+            "status": "new",
+            "priority": 2,
+        }
+        response = self.client.post(reverse("ticket_create"), data, follow=True)
+        self.assertContains(response, "Заявка создана.")
+
+    def test_create_invalid_shows_errors(self):
+        response = self.client.post(reverse("ticket_create"), {"title": ""})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Ticket.objects.count(), 0)
+        self.assertContains(response, "Обязательное поле")
+
 
 class TicketUpdateViewTests(TestCase):
     def setUp(self):
@@ -151,3 +167,16 @@ class AddCommentTests(TestCase):
         self.assertRedirects(
             response, reverse("ticket_detail", args=[self.ticket.pk])
         )
+
+    def test_invalid_comment_shows_errors_and_keeps_text(self):
+        data = {
+            "author_name": "",
+            "message": "Текст без автора",
+        }
+        response = self.client.post(
+            reverse("ticket_add_comment", args=[self.ticket.pk]), data
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.ticket.comments.count(), 0)
+        self.assertContains(response, "Текст без автора")
+        self.assertContains(response, "Обязательное поле")

--- a/corp_site/tickets/views.py
+++ b/corp_site/tickets/views.py
@@ -1,4 +1,7 @@
-from django.shortcuts import get_object_or_404, redirect
+from django.contrib import messages
+from django.contrib.messages.views import SuccessMessageMixin
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse_lazy
 from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
 
 from .forms import CommentForm, TicketForm
@@ -24,36 +27,51 @@ class TicketDetailView(DetailView):
         return context
 
 
-class TicketCreateView(CreateView):
+class TicketCreateView(SuccessMessageMixin, CreateView):
     model = Ticket
     form_class = TicketForm
     template_name = "tickets/ticket_form.html"
+    success_message = "Заявка создана."
 
     def get_success_url(self):
         return self.object.get_absolute_url()
 
 
-class TicketUpdateView(UpdateView):
+class TicketUpdateView(SuccessMessageMixin, UpdateView):
     model = Ticket
     form_class = TicketForm
     template_name = "tickets/ticket_form.html"
+    success_message = "Заявка обновлена."
 
     def get_success_url(self):
         return self.object.get_absolute_url()
 
 
-class TicketDeleteView(DeleteView):
+class TicketDeleteView(SuccessMessageMixin, DeleteView):
     model = Ticket
     template_name = "tickets/ticket_confirm_delete.html"
-    success_url = "/tickets/"
+    success_url = reverse_lazy("ticket_list")
+    success_message = "Заявка удалена."
 
 
 def add_comment(request, pk):
     ticket = get_object_or_404(Ticket, pk=pk)
-    if request.method == "POST":
-        form = CommentForm(request.POST)
-        if form.is_valid():
-            comment = form.save(commit=False)
-            comment.ticket = ticket
-            comment.save()
-    return redirect("ticket_detail", pk=ticket.pk)
+    if request.method != "POST":
+        return redirect("ticket_detail", pk=ticket.pk)
+
+    form = CommentForm(request.POST)
+    if form.is_valid():
+        comment = form.save(commit=False)
+        comment.ticket = ticket
+        comment.save()
+        messages.success(request, "Комментарий добавлен.")
+        return redirect("ticket_detail", pk=ticket.pk)
+
+    # Невалидная форма: показываем страницу заявки с ошибками,
+    # чтобы введённый текст не потерялся.
+    context = {
+        "ticket": ticket,
+        "comments": ticket.comments.all(),
+        "comment_form": form,
+    }
+    return render(request, "tickets/ticket_detail.html", context)

--- a/corp_site/tickets/views.py
+++ b/corp_site/tickets/views.py
@@ -1,5 +1,7 @@
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
+from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
@@ -13,6 +15,34 @@ class TicketListView(ListView):
     context_object_name = "tickets"
     template_name = "tickets/ticket_list.html"
     paginate_by = 10
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        q = self.request.GET.get("q", "").strip()
+        status = self.request.GET.get("status", "")
+        priority = self.request.GET.get("priority", "")
+        if q:
+            queryset = queryset.filter(
+                Q(title__icontains=q) | Q(description__icontains=q)
+            )
+        if status in Ticket.Status.values:
+            queryset = queryset.filter(status=status)
+        if priority.isdigit() and int(priority) in Ticket.Priority.values:
+            queryset = queryset.filter(priority=int(priority))
+        return queryset
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["search_query"] = self.request.GET.get("q", "").strip()
+        context["status_filter"] = self.request.GET.get("status", "")
+        context["priority_filter"] = self.request.GET.get("priority", "")
+        context["status_choices"] = Ticket.Status.choices
+        context["priority_choices"] = Ticket.Priority.choices
+        # Строка запроса без page — чтобы пагинация не сбрасывала фильтры.
+        params = self.request.GET.copy()
+        params.pop("page", None)
+        context["querystring"] = params.urlencode()
+        return context
 
 
 class TicketDetailView(DetailView):
@@ -37,7 +67,7 @@ class TicketCreateView(SuccessMessageMixin, CreateView):
         return self.object.get_absolute_url()
 
 
-class TicketUpdateView(SuccessMessageMixin, UpdateView):
+class TicketUpdateView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
     model = Ticket
     form_class = TicketForm
     template_name = "tickets/ticket_form.html"
@@ -47,7 +77,7 @@ class TicketUpdateView(SuccessMessageMixin, UpdateView):
         return self.object.get_absolute_url()
 
 
-class TicketDeleteView(SuccessMessageMixin, DeleteView):
+class TicketDeleteView(LoginRequiredMixin, SuccessMessageMixin, DeleteView):
     model = Ticket
     template_name = "tickets/ticket_confirm_delete.html"
     success_url = reverse_lazy("ticket_list")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Django==5.2.8
 gunicorn==23.0.0
 whitenoise==6.8.2
+dj-database-url==2.3.0
+psycopg[binary]==3.2.9


### PR DESCRIPTION
## Что исправлено

Аудит показал, что **Django CI не прошёл ни одного из 29 запусков за всю историю проекта**, а на Render сайт неработоспособен (403 CSRF на любой POST-форме). Этот PR чинит обе проблемы, ряд недочётов качества и добавляет поиск/фильтры и авторизацию.

### 1. CI (`.github/workflows/django.yml`) — теперь зелёный ✅
- Шаги `manage.py check`/`test` запускались из корня репозитория, а `manage.py` лежит в `corp_site/` → добавлен `working-directory: corp_site`.
- Матрица `[3.10, 3.11, 3.12]` без кавычек: YAML читал `3.10` как число `3.1`, и job падал на установке несуществующего Python → версии взяты в кавычки.
- `actions/setup-python` обновлён v4 → v5, убран неиспользуемый `DJANGO_SETTINGS_MODULE`.

Первый запуск на этом PR (run #31) — все 4 джобы успешны, впервые в истории репозитория.

### 2. Прод на Render (`settings.py`)
- **`SECURE_PROXY_SSL_HEADER`** — без него Django за HTTPS-прокси Render считал соединение HTTP и резал все POST-формы с 403 CSRF.
- `RENDER_EXTERNAL_HOSTNAME` автоматически добавляется в `ALLOWED_HOSTS` и `CSRF_TRUSTED_ORIGINS`.
- `DEBUG` по умолчанию `False` на Render (по env-переменной `RENDER`), `True` локально.
- `SECRET_KEY` обязателен при выключенном DEBUG.
- Поддержка `DATABASE_URL` (dj-database-url + psycopg): внешний Postgres вместо SQLite на эфемерном диске Render, который стирается при каждом деплое. Инструкция — в README.
- Secure-флаги для session/CSRF cookies при DEBUG=False.

### 3. Качество приложения tickets
- Невалидная форма комментария больше не теряется молча: страница рендерится с ошибками и введённым текстом.
- Flash-сообщения об успехе для создания/обновления/удаления заявки и комментария.
- Бейджи статуса/приоритета: дублированные if-цепочки в шаблонах заменены свойствами модели.
- `TicketDeleteView.success_url` через `reverse_lazy`.

### 4. Поиск, фильтры и авторизация
- Поиск по заголовку и описанию + фильтры по статусу и приоритету в списке заявок; пагинация сохраняет активные фильтры.
- Вход/выход через `django.contrib.auth` (`/accounts/login/`), Bootstrap-шаблон логина, имя пользователя и кнопка «Выйти» в навбаре.
- Редактирование и удаление заявок — только для залогиненных (аноним получает редирект на логин, кнопки скрыты).
- `build.sh` создаёт администратора из `DJANGO_SUPERUSER_USERNAME`/`DJANGO_SUPERUSER_PASSWORD`, чтобы завести админа на Render без доступа к shell.

### Тесты
10 → 20: невалидные формы, flash-сообщение, поиск, фильтры по статусу/приоритету, пустая выдача поиска, редиректы анонимов на логин.

```
Ran 20 tests — OK
ruff check . — All checks passed!
manage.py check --deploy — только необязательные предупреждения (HSTS)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hp95H8Ew86B2Wo9RtQEnmA