### PR TITLE
Enable GitHub Pages automatically in ColorFlow deploy workflow

### DIFF
--- a/.github/workflows/colorflow-pages.yml
+++ b/.github/workflows/colorflow-pages.yml
@@ -29,6 +29,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          # Включает GitHub Pages автоматически, если он выключен в настройках
+          # репозитория — без этого шаг падает и деплой не работает.
+          enablement: true
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Все 4 запуска деплоя ColorFlow на GitHub Pages падали: Pages не включён в настройках репозитория, и шаг `configure-pages` завершался ошибкой.

Флаг `enablement: true` у `actions/configure-pages@v5` включает Pages прямо из workflow (право `pages: write` уже выдано). После мержа деплой запускается вручную через workflow_dispatch или автоматически при изменениях в `colorflow/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hp95H8Ew86B2Wo9RtQEnmA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hp95H8Ew86B2Wo9RtQEnmA)_