### PR TITLE
Drop github-pages environment block so Pages deploy can start

### DIFF
--- a/.github/workflows/colorflow-pages.yml
+++ b/.github/workflows/colorflow-pages.yml
@@ -20,9 +20,9 @@ concurrency:
 
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    # Без блока environment: пока Pages не включён, environment github-pages
+    # не существует, и job с ним падает мгновенно, не дойдя до шагов.
+    # configure-pages с enablement: true включает Pages при первом запуске.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Run #5 упал за 1 секунду, не выполнив ни одного шага: пока GitHub Pages выключен, environment `github-pages` не существует, и job, который его объявляет, отклоняется ещё до старта — поэтому `enablement: true` из предыдущего фикса даже не успевал сработать.

Без блока `environment` job запускается: `configure-pages` (с `enablement: true`) включает Pages при первом запуске, `deploy-pages` публикует сайт.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hp95H8Ew86B2Wo9RtQEnmA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hp95H8Ew86B2Wo9RtQEnmA)_