### PR TITLE
Restore github-pages environment now that Pages is enabled

### DIFF
--- a/.github/workflows/colorflow-pages.yml
+++ b/.github/workflows/colorflow-pages.yml
@@ -20,9 +20,9 @@ concurrency:
 
 jobs:
   deploy:
-    # Без блока environment: пока Pages не включён, environment github-pages
-    # не существует, и job с ним падает мгновенно, не дойдя до шагов.
-    # configure-pages с enablement: true включает Pages при первом запуске.
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Запуск #6 подтвердил диагноз: без блока `environment` job стартовал, и `configure-pages` с `enablement: true` **успешно включил GitHub Pages**, но `deploy-pages@v4` отказался деплоить с ошибкой «Missing environment».

Теперь, когда Pages включён, environment `github-pages` существует — возвращаем исходный блок `environment`, и деплой проходит до конца.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hp95H8Ew86B2Wo9RtQEnmA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hp95H8Ew86B2Wo9RtQEnmA)_