### PR TITLE
Publish ColorFlow to gh-pages branch instead of actions/deploy-pages

### DIFF
--- a/.github/workflows/colorflow-pages.yml
+++ b/.github/workflows/colorflow-pages.yml
@@ -8,40 +8,32 @@ on:
       - '.github/workflows/colorflow-pages.yml'
   workflow_dispatch:
 
+# Pages в настройках репозитория работает в режиме «deploy from a branch»
+# и ждёт ветку gh-pages (деплой через actions/deploy-pages отклоняется:
+# «Deployments are only allowed from gh-pages»). Поэтому просто публикуем
+# содержимое colorflow/ в ветку gh-pages — дальше GitHub делает всё сам.
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-# Allow only one concurrent deployment, queueing trailing changes.
 concurrency:
   group: pages
   cancel-in-progress: false
 
 jobs:
   deploy:
-    # Не 'github-pages': на автосозданном environment осталась политика
-    # deployment branches, которая мгновенно отклоняет job ещё до шагов.
-    # Свежий environment создаётся без ограничений.
-    environment:
-      name: pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Configure Pages
-        uses: actions/configure-pages@v5
-        with:
-          # Включает GitHub Pages автоматически, если он выключен в настройках
-          # репозитория — без этого шаг падает и деплой не работает.
-          enablement: true
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          # Publish only the colorflow directory, so the PWA lives at /index.html
-          # of the deployed site (root of the GH Pages domain).
-          path: ./colorflow
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Publish colorflow/ to gh-pages branch
+        run: |
+          cd colorflow
+          touch .nojekyll
+          git init -b gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Deploy ColorFlow from ${GITHUB_SHA::7}"
+          git push --force "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Запуск №8 наконец показал настоящую причину всех падений деплоя: Pages в настройках репозитория работает в режиме **«deploy from a branch»** и принимает деплой только из ветки `gh-pages` («Deployments are only allowed from gh-pages»), поэтому каждая попытка через `actions/deploy-pages` отклонялась.

Вместо борьбы с настройкой — публикуем содержимое `colorflow/` в ветку `gh-pages`: workflow коммитит статику туда, а встроенный Pages-билд GitHub сам раскладывает сайт.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hp95H8Ew86B2Wo9RtQEnmA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hp95H8Ew86B2Wo9RtQEnmA)_