### PR TITLE
Add workflow that creates the Render service via API

### DIFF
--- a/.github/workflows/render-setup.yml
+++ b/.github/workflows/render-setup.yml
@@ -1,0 +1,127 @@
+name: Create Render service and deploy
+
+# Одноразовая автоматизация: создаёт web-сервис corp-site на Render через
+# его API (песочница Claude не имеет доступа к api.render.com, а раннеры
+# GitHub Actions — имеют) и ждёт окончания первого деплоя.
+#
+# Требуется секрет репозитория RENDER_API_KEY:
+# Render Dashboard -> Account Settings -> API Keys -> Create API Key,
+# затем GitHub -> Settings -> Secrets and variables -> Actions -> New secret.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Create service and wait for deploy
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          REPO_URL: https://github.com/${{ github.repository }}
+        run: |
+          python3 - <<'PYEOF'
+          import json
+          import os
+          import secrets
+          import sys
+          import time
+          import urllib.request
+
+          API = "https://api.render.com/v1"
+          KEY = os.environ.get("RENDER_API_KEY", "")
+          if not KEY:
+              sys.exit("RENDER_API_KEY secret is not set. Add it in repo Settings -> Secrets -> Actions.")
+
+          def call(method, path, body=None):
+              req = urllib.request.Request(
+                  API + path,
+                  data=json.dumps(body).encode() if body is not None else None,
+                  method=method,
+                  headers={
+                      "Authorization": f"Bearer {KEY}",
+                      "Accept": "application/json",
+                      "Content-Type": "application/json",
+                  },
+              )
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      data = r.read()
+                      return r.status, json.loads(data) if data else None
+              except urllib.error.HTTPError as e:
+                  return e.code, json.loads(e.read() or b"null")
+
+          status, owners = call("GET", "/owners?limit=20")
+          if status != 200 or not owners:
+              sys.exit(f"Cannot list owners (HTTP {status}): {owners}")
+          owner_id = owners[0]["owner"]["id"]
+          print(f"Owner: {owner_id}")
+
+          # Уже существует? Тогда просто деплоим заново.
+          status, existing = call("GET", f"/services?name=corp-site&ownerId={owner_id}&limit=10")
+          service = None
+          if status == 200 and existing:
+              for item in existing:
+                  if item["service"]["name"] == "corp-site":
+                      service = item["service"]
+                      print(f"Service already exists: {service['id']}")
+                      break
+
+          if service is None:
+              payload = {
+                  "type": "web_service",
+                  "name": "corp-site",
+                  "ownerId": owner_id,
+                  "repo": os.environ["REPO_URL"],
+                  "branch": "main",
+                  "autoDeploy": "yes",
+                  "envVars": [
+                      {"key": "SECRET_KEY", "value": secrets.token_urlsafe(50)},
+                      {"key": "PYTHON_VERSION", "value": "3.11.6"},
+                  ],
+                  "serviceDetails": {
+                      "plan": "free",
+                      "runtime": "python",
+                      "envSpecificDetails": {
+                          "buildCommand": "./bin/build.sh",
+                          "startCommand": "cd corp_site && gunicorn corp_site.wsgi:application --bind 0.0.0.0:$PORT",
+                      },
+                  },
+              }
+              status, created = call("POST", "/services", payload)
+              if status not in (200, 201):
+                  sys.exit(f"Service creation failed (HTTP {status}): {json.dumps(created, indent=2)}")
+              service = created["service"]
+              print(f"Service created: {service['id']}")
+
+          url = service.get("serviceDetails", {}).get("url") or "(url appears after first deploy)"
+          print(f"Service URL: {url}")
+
+          # Ждём завершения последнего деплоя.
+          deadline = time.time() + 25 * 60
+          final = None
+          while time.time() < deadline:
+              status, deploys = call("GET", f"/services/{service['id']}/deploys?limit=1")
+              if status == 200 and deploys:
+                  d = deploys[0]["deploy"]
+                  print(f"Deploy {d['id']}: {d['status']}")
+                  if d["status"] in ("live",):
+                      final = "live"
+                      break
+                  if d["status"] in ("build_failed", "update_failed", "canceled", "deactivated"):
+                      final = d["status"]
+                      break
+              time.sleep(20)
+
+          status, service_info = call("GET", f"/services/{service['id']}")
+          if status == 200:
+              url = service_info.get("serviceDetails", {}).get("url", url)
+
+          print("=" * 60)
+          print(f"RESULT: deploy status = {final}")
+          print(f"SITE URL: {url}")
+          print("=" * 60)
+          if final != "live":
+              sys.exit("Deploy did not reach 'live' state — see log above.")
+          PYEOF


### PR DESCRIPTION
Песочница Claude не имеет сетевого доступа к api.render.com, а раннеры GitHub Actions — имеют. Этот workflow (ручной запуск) создаёт web-сервис `corp-site` на Render через API с теми же настройками, что в `render.yaml`, ждёт окончания первого деплоя и печатает публичный URL сайта в лог.

Требуется секрет репозитория `RENDER_API_KEY` (Render → Account Settings → API Keys). Повторный запуск безопасен: если сервис уже существует, workflow просто дождётся актуального деплоя и покажет URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hp95H8Ew86B2Wo9RtQEnmA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hp95H8Ew86B2Wo9RtQEnmA)_