### PR TITLE
Trigger Render setup workflow on push as dispatch fallback

### DIFF
--- a/.github/workflows/render-setup.yml
+++ b/.github/workflows/render-setup.yml
@@ -10,6 +10,14 @@ name: Create Render service and deploy
 
 on:
   workflow_dispatch:
+  # Токен интеграции не может дёргать workflow_dispatch (403), поэтому
+  # workflow также запускается пушем в main, затрагивающим этот файл
+  # или файл-маркер .render-deploy.
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/render-setup.yml'
+      - '.render-deploy'
 
 jobs:
   setup:


### PR DESCRIPTION
Токен GitHub-интеграции не может вызывать `workflow_dispatch` (403), поэтому workflow создания сервиса на Render дополнительно запускается пушем в `main`, который затрагивает сам файл workflow или файл-маркер `.render-deploy`. Мерж этого PR сразу запустит деплой.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hp95H8Ew86B2Wo9RtQEnmA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hp95H8Ew86B2Wo9RtQEnmA)_