### PR TITLE
Разбить бандл дашборда, CI для фронтенда и починка деплоя на ВМ

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,0 +1,49 @@
+name: Dashboard CI
+
+on:
+  push:
+    paths:
+      - "salon-dashboard/**"
+      - ".github/workflows/dashboard.yml"
+  pull_request:
+    paths:
+      - "salon-dashboard/**"
+      - ".github/workflows/dashboard.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: salon-dashboard
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: salon-dashboard/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+
+      # Стартовый чанк не должен снова вобрать выгрузку салона (388 КБ JSON)
+      # или Recharts — они грузятся только на своих маршрутах, см. README.
+      - name: Check entry chunk size
+        run: |
+          entry=$(node -e "
+            const {readFileSync}=require('fs')
+            const html=readFileSync('dist/index.html','utf8')
+            const m=html.match(/src=\"\/assets\/(index-[^\"]+\.js)\"/)
+            if(!m) throw new Error('entry chunk not found in dist/index.html')
+            process.stdout.write(m[1])
+          ")
+          size=$(stat -c%s "dist/assets/$entry")
+          echo "entry chunk $entry: $size bytes"
+          if [ "$size" -gt 400000 ]; then
+            echo "::error::Стартовый чанк вырос до $size байт (лимит 400000)."
+            echo "Скорее всего модуль, который грузится всегда, начал импортировать"
+            echo "lib/data (тянет salon.json) или Recharts — см. salon-dashboard/README.md."
+            exit 1
+          fi

--- a/.github/workflows/deploy-vest-smr.yml
+++ b/.github/workflows/deploy-vest-smr.yml
@@ -56,7 +56,9 @@ jobs:
         env:
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH != '' && secrets.DEPLOY_PATH || '/var/www/vest-smr' }}
         run: |
-          rsync -az --delete \
+          # --exclude=/data/: там лежит news.json от update-news.yml, его нет
+          # в dist/, и без исключения --delete стирал бы дайджест при деплое
+          rsync -az --delete --exclude=/data/ \
             -e "ssh -i ~/.ssh/id_deploy" \
             salon-dashboard/dist/ \
             "${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:$DEPLOY_PATH/"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,6 +3,21 @@
 Дашборд — статический сайт (папка `salon-dashboard/dist` после сборки).
 Для его работы на ВМ достаточно nginx.
 
+## Чек-лист: что нужно, чтобы сайт открылся на vest-smr.ru
+
+1. **ВМ**: nginx установлен, конфиг из репозитория подключён, каталог
+   `/var/www/vest-smr` существует и доступен пользователю деплоя — раздел 1 ниже.
+2. **DNS**: A-запись `vest-smr.ru` (и `www`) на публичный статический IP ВМ,
+   в группе безопасности открыты порты 80 и 443.
+3. **Файлы сайта на ВМ** — любым из двух способов:
+   - руками сейчас: `deploy/deploy.sh user@<IP-ВМ>` (раздел 3);
+   - автоматически при пуше в `main`: секреты `DEPLOY_HOST` / `DEPLOY_USER` /
+     `DEPLOY_SSH_KEY` в репозитории (раздел 2). Workflow срабатывает только на
+     `main`, поэтому изменения дашборда должны быть влиты в `main`.
+4. **HTTPS**: `certbot --nginx` после того как DNS начал указывать на ВМ.
+5. **Новости** (необязательно): секреты `YC_API_KEY` / `YC_FOLDER_ID` —
+   последний раздел.
+
 ## 1. Разовая настройка ВМ (выполняется один раз)
 
 Подключитесь к ВМ по SSH и выполните:
@@ -57,11 +72,23 @@ cat deploy_key.pub >> ~/.ssh/authorized_keys
 
 ## 3. Ручной деплой (без GitHub Actions)
 
+Скрипт делает то же, что workflow — собирает и заливает по rsync:
+
+```bash
+deploy/deploy.sh yc-user@<IP-ВМ>              # путь по умолчанию /var/www/vest-smr
+deploy/deploy.sh yc-user@vest-smr.ru /var/www/vest-smr
+```
+
+То же вручную:
+
 ```bash
 cd salon-dashboard
 npm ci && npm run build
-rsync -az --delete dist/ user@<IP-ВМ>:/var/www/vest-smr/
+rsync -az --delete --exclude=/data/ dist/ user@<IP-ВМ>:/var/www/vest-smr/
 ```
+
+`--exclude=/data/` обязателен: в `dist/` нет каталога `data/`, а на ВМ там лежит
+ежедневный `news.json`, и без исключения `--delete` стирал бы его при каждом деплое.
 
 ## Обновление данных
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Ручная выкладка дашборда на ВМ (то же, что делает deploy-vest-smr.yml).
+# Запускать из корня репозитория, нужен ssh-доступ на ВМ.
+#
+#   deploy/deploy.sh yc-user@1.2.3.4
+#   deploy/deploy.sh yc-user@vest-smr.ru /var/www/vest-smr
+#
+# Первый аргумент — user@host, второй (необязательно) — путь на ВМ.
+set -euo pipefail
+
+TARGET="${1:-${DEPLOY_TARGET:-}}"
+DEPLOY_PATH="${2:-${DEPLOY_PATH:-/var/www/vest-smr}}"
+
+if [ -z "$TARGET" ]; then
+  echo "Укажите цель: deploy/deploy.sh user@host [/var/www/vest-smr]" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root/salon-dashboard"
+
+echo "==> Сборка"
+npm ci
+npm run build
+
+echo "==> Проверка сборки"
+test -f dist/index.html || { echo "dist/index.html не найден" >&2; exit 1; }
+
+echo "==> Выкладка в $TARGET:$DEPLOY_PATH"
+ssh "$TARGET" "mkdir -p '$DEPLOY_PATH/data'"
+# --exclude=/data/: дайджест новостей на ВМ обновляется отдельно и не входит
+# в dist/, иначе --delete стирал бы его при каждом деплое
+rsync -az --delete --exclude=/data/ dist/ "$TARGET:$DEPLOY_PATH/"
+
+echo "==> Готово. Проверьте: curl -sI http://${TARGET#*@}/ | head -1"

--- a/deploy/nginx-vest-smr.conf
+++ b/deploy/nginx-vest-smr.conf
@@ -24,6 +24,12 @@ server {
         add_header Cache-Control "no-cache";
     }
 
+    # index.html не кешируем: имена чанков меняются при каждом деплое,
+    # иначе браузер будет запрашивать уже удалённые /assets/*.js
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+
     location /assets/ {
         expires 30d;
         add_header Cache-Control "public, immutable";

--- a/salon-dashboard/README.md
+++ b/salon-dashboard/README.md
@@ -1,32 +1,60 @@
-# React + TypeScript + Vite
+# salon-dashboard
 
-This template provides a minimal setup to get React working in Vite with HMR and some Oxlint rules.
+Фронтенд vest-smr.ru: дашборд мониторинга ИИ-индустрии (корень сайта) и аналитика салона (раздел `/salon`).
+React 19 + TypeScript + Vite, стили — Tailwind, графики — Recharts, роутинг — wouter.
 
-Currently, two official plugins are available:
+## Команды
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
-
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the Oxlint configuration
-
-If you are developing a production application, we recommend enabling type-aware lint rules by installing `oxlint-tsgolint` and editing `.oxlintrc.json`:
-
-```json
-{
-  "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["react", "typescript", "oxc"],
-  "options": {
-    "typeAware": true
-  },
-  "rules": {
-    "react/rules-of-hooks": "error",
-    "react/only-export-components": ["warn", { "allowConstantExport": true }]
-  }
-}
+```bash
+npm ci          # установка зависимостей
+npm run dev     # dev-сервер с HMR
+npm run build   # tsc -b + vite build → dist/
+npm run lint    # oxlint
+npm run preview # локальный просмотр собранного dist/
 ```
 
-See the [Oxlint rules documentation](https://oxc.rs/docs/guide/usage/linter/rules) for the full list of rules and categories.
+## Структура
+
+```
+src/
+  App.tsx              маршруты (все страницы — lazy)
+  components/Layout.tsx шапка, навигация, футер
+  components/ui/       card, badge, button
+  data/report.ts       данные отчёта по ИИ: метрики, модели, цены, рекомендации
+  data/salon.json      выгрузка salonbackup (1127 визитов), ~388 КБ
+  hooks/useNews.ts     подгрузка /data/news.json с фолбэком на вшитый дайджест
+  lib/format.ts        формат чисел и дат, без зависимостей от данных
+  lib/data.ts          датасет салона: entries, expenses, masters, прайс
+  pages/               страницы разделов ИИ и салона
+```
+
+## Разбиение бандла
+
+Страницы подключены через `lazy()`, поэтому Recharts и `salon.json` не попадают
+в стартовую загрузку главной страницы: `/` тянет ~228 КБ (~75 КБ gzip), выгрузка
+салона (~227 КБ) грузится только при переходе в `/salon`.
+
+Чтобы это не сломалось:
+
+- **не импортируйте `lib/data` из `Layout` или других модулей, которые грузятся всегда** —
+  через него в основной чанк попадёт `salon.json`. Для формата чисел и дат
+  используйте `lib/format` (`lib/data` реэкспортит его для страниц салона);
+- новые страницы добавляйте в `App.tsx` тоже через `lazy(() => import(...))`.
+
+После сборки проверяйте, что в выводе `npm run build` нет предупреждения
+о чанках больше 500 КБ, кроме вендорного чанка Recharts.
+
+## Данные новостей
+
+`useNews` в рантайме запрашивает `/data/news.json`; если файла нет — показывает
+дайджест, вшитый в `data/report.ts`. Файл публикуется на сервер отдельно
+воркфлоу `.github/workflows/update-news.yml` (см. `deploy/README.md`), поэтому
+обновление новостей не требует пересборки фронтенда. В nginx `/data/news.json`
+и `index.html` отдаются с `Cache-Control: no-cache`, а `/assets/` — с
+долгим кешем, так как имена файлов содержат хеш.
+
+## Деплой
+
+Сборка выкладывается в `/var/www/vest-smr` на VM воркфлоу
+`.github/workflows/deploy-vest-smr.yml`, конфиг nginx — `deploy/nginx-vest-smr.conf`.
+Вариант в контейнере: `Dockerfile` + `nginx.container.conf` (порт 8080).

--- a/salon-dashboard/nginx.container.conf
+++ b/salon-dashboard/nginx.container.conf
@@ -14,6 +14,12 @@ server {
         add_header Cache-Control "no-cache";
     }
 
+    # index.html не кешируем: имена чанков меняются при каждом деплое,
+    # иначе браузер будет запрашивать уже удалённые /assets/*.js
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+
     location /assets/ {
         expires 30d;
         add_header Cache-Control "public, immutable";

--- a/salon-dashboard/src/App.tsx
+++ b/salon-dashboard/src/App.tsx
@@ -1,36 +1,50 @@
+import { lazy, Suspense } from 'react'
 import { Route, Switch } from 'wouter'
 import Layout from './components/Layout'
-import AiDashboard from './pages/AiDashboard'
-import News from './pages/News'
-import NewsDetail from './pages/NewsDetail'
-import ModelsComparison from './pages/ModelsComparison'
-import PriceHistory from './pages/PriceHistory'
-import CostCalculator from './pages/CostCalculator'
-import SalonDashboard from './pages/SalonDashboard'
-import Masters from './pages/Masters'
-import History from './pages/History'
-import SalonCalculator from './pages/SalonCalculator'
+
+/* Страницы грузятся по требованию: recharts и выгрузка салона (388 КБ JSON)
+   не попадают в стартовый бандл главной страницы. */
+const AiDashboard = lazy(() => import('./pages/AiDashboard'))
+const News = lazy(() => import('./pages/News'))
+const NewsDetail = lazy(() => import('./pages/NewsDetail'))
+const ModelsComparison = lazy(() => import('./pages/ModelsComparison'))
+const PriceHistory = lazy(() => import('./pages/PriceHistory'))
+const CostCalculator = lazy(() => import('./pages/CostCalculator'))
+const SalonDashboard = lazy(() => import('./pages/SalonDashboard'))
+const Masters = lazy(() => import('./pages/Masters'))
+const History = lazy(() => import('./pages/History'))
+const SalonCalculator = lazy(() => import('./pages/SalonCalculator'))
+
+function PageFallback() {
+  return (
+    <div className="py-16 text-center text-sm text-muted-foreground" role="status">
+      Загрузка…
+    </div>
+  )
+}
 
 export default function App() {
   return (
     <Layout>
-      <Switch>
-        <Route path="/" component={AiDashboard} />
-        <Route path="/news" component={News} />
-        <Route path="/news/:id" component={NewsDetail} />
-        <Route path="/models" component={ModelsComparison} />
-        <Route path="/prices" component={PriceHistory} />
-        <Route path="/calculator" component={CostCalculator} />
-        <Route path="/salon" component={SalonDashboard} />
-        <Route path="/salon/masters" component={Masters} />
-        <Route path="/salon/history" component={History} />
-        <Route path="/salon/calculator" component={SalonCalculator} />
-        <Route>
-          <div className="container py-16 text-center text-muted-foreground">
-            Страница не найдена
-          </div>
-        </Route>
-      </Switch>
+      <Suspense fallback={<PageFallback />}>
+        <Switch>
+          <Route path="/" component={AiDashboard} />
+          <Route path="/news" component={News} />
+          <Route path="/news/:id" component={NewsDetail} />
+          <Route path="/models" component={ModelsComparison} />
+          <Route path="/prices" component={PriceHistory} />
+          <Route path="/calculator" component={CostCalculator} />
+          <Route path="/salon" component={SalonDashboard} />
+          <Route path="/salon/masters" component={Masters} />
+          <Route path="/salon/history" component={History} />
+          <Route path="/salon/calculator" component={SalonCalculator} />
+          <Route>
+            <div className="container py-16 text-center text-muted-foreground">
+              Страница не найдена
+            </div>
+          </Route>
+        </Switch>
+      </Suspense>
     </Layout>
   )
 }

--- a/salon-dashboard/src/components/Layout.tsx
+++ b/salon-dashboard/src/components/Layout.tsx
@@ -4,7 +4,7 @@ import {
   BarChart3, Calculator, Cpu, LineChart, Newspaper, Scissors, Users,
 } from 'lucide-react'
 import { REPORT } from '../data/report'
-import { fmtDate } from '../lib/data'
+import { fmtDate } from '../lib/format'
 
 const MAIN_NAV = [
   { href: '/', label: 'Дашборд', icon: BarChart3 },

--- a/salon-dashboard/src/lib/data.ts
+++ b/salon-dashboard/src/lib/data.ts
@@ -1,5 +1,9 @@
 import raw from '../data/salon.json'
 
+/* Хелперы форматирования переехали в ./format, чтобы salon.json не тянулся
+   в основной чанк. Реэкспорт оставлен для страниц салона. */
+export * from './format'
+
 export interface Entry {
   id: string
   date: string
@@ -96,34 +100,3 @@ export const SERIES_COLORS: Record<string, string> = {
 }
 
 export const monthsInData: string[] = [...new Set(entries.map((e) => e.date.slice(0, 7)))].sort()
-
-export const MONTH_FULL = [
-  'Январь', 'Февраль', 'Март', 'Апрель', 'Май', 'Июнь',
-  'Июль', 'Август', 'Сентябрь', 'Октябрь', 'Ноябрь', 'Декабрь',
-]
-export const MONTH_SHORT = [
-  'янв', 'фев', 'мар', 'апр', 'май', 'июн',
-  'июл', 'авг', 'сен', 'окт', 'ноя', 'дек',
-]
-
-const nf = new Intl.NumberFormat('ru-RU')
-export const rub = (v: number) => `${nf.format(Math.round(v))} ₽`
-export const num = (v: number) => nf.format(v)
-
-export function pluralRu(n: number, one: string, few: string, many: string): string {
-  const m10 = n % 10
-  const m100 = n % 100
-  if (m10 === 1 && m100 !== 11) return one
-  if (m10 >= 2 && m10 <= 4 && (m100 < 10 || m100 >= 20)) return few
-  return many
-}
-
-export function fmtDate(iso: string): string {
-  const d = new Date(iso.length === 10 ? iso + 'T12:00:00' : iso)
-  return `${d.getDate()} ${MONTH_SHORT[d.getMonth()]} ${d.getFullYear()}`
-}
-
-export function monthLabel(ym: string): string {
-  const [y, m] = ym.split('-')
-  return `${MONTH_FULL[Number(m) - 1]} ${y}`
-}

--- a/salon-dashboard/src/lib/format.ts
+++ b/salon-dashboard/src/lib/format.ts
@@ -1,0 +1,33 @@
+/* Форматирование и локаль. Без импорта данных — модуль попадает в основной чанк,
+   поэтому здесь не должно появиться зависимостей от salon.json или report.ts. */
+
+export const MONTH_FULL = [
+  'Январь', 'Февраль', 'Март', 'Апрель', 'Май', 'Июнь',
+  'Июль', 'Август', 'Сентябрь', 'Октябрь', 'Ноябрь', 'Декабрь',
+]
+export const MONTH_SHORT = [
+  'янв', 'фев', 'мар', 'апр', 'май', 'июн',
+  'июл', 'авг', 'сен', 'окт', 'ноя', 'дек',
+]
+
+const nf = new Intl.NumberFormat('ru-RU')
+export const rub = (v: number) => `${nf.format(Math.round(v))} ₽`
+export const num = (v: number) => nf.format(v)
+
+export function pluralRu(n: number, one: string, few: string, many: string): string {
+  const m10 = n % 10
+  const m100 = n % 100
+  if (m10 === 1 && m100 !== 11) return one
+  if (m10 >= 2 && m10 <= 4 && (m100 < 10 || m100 >= 20)) return few
+  return many
+}
+
+export function fmtDate(iso: string): string {
+  const d = new Date(iso.length === 10 ? iso + 'T12:00:00' : iso)
+  return `${d.getDate()} ${MONTH_SHORT[d.getMonth()]} ${d.getFullYear()}`
+}
+
+export function monthLabel(ym: string): string {
+  const [y, m] = ym.split('-')
+  return `${MONTH_FULL[Number(m) - 1]} ${y}`
+}

--- a/salon-dashboard/src/pages/AiDashboard.tsx
+++ b/salon-dashboard/src/pages/AiDashboard.tsx
@@ -6,7 +6,7 @@ import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { AI_METRICS, AI_TAGS, RECOMMENDATIONS, REPORT } from '../data/report'
 import { useNews } from '../hooks/useNews'
-import { fmtDate } from '../lib/data'
+import { fmtDate } from '../lib/format'
 
 const QUICK_LINKS = [
   { href: '/models', title: 'Сравнение моделей', desc: 'DeepSeek V4 Flash, GPT-5.6, Qwen3.8-Max, Muse Spark, Grok 4.5' },

--- a/salon-dashboard/src/pages/News.tsx
+++ b/salon-dashboard/src/pages/News.tsx
@@ -6,7 +6,7 @@ import { Badge } from '../components/ui/badge'
 import { useFavorites } from '../hooks/useFavorites'
 import { AI_TAGS, REPORT } from '../data/report'
 import { useNews } from '../hooks/useNews'
-import { fmtDate } from '../lib/data'
+import { fmtDate } from '../lib/format'
 
 export default function News() {
   const [tag, setTag] = useState('Все')

--- a/salon-dashboard/src/pages/NewsDetail.tsx
+++ b/salon-dashboard/src/pages/NewsDetail.tsx
@@ -6,7 +6,7 @@ import { Button } from '../components/ui/button'
 import { ShareMenu } from '../components/ShareMenu'
 import { useFavorites } from '../hooks/useFavorites'
 import { useNews } from '../hooks/useNews'
-import { fmtDate } from '../lib/data'
+import { fmtDate } from '../lib/format'
 
 export default function NewsDetail() {
   const [, params] = useRoute('/news/:id')


### PR DESCRIPTION
Продолжение PR #21 — база выставлена на его ветку, чтобы в diff были только эти изменения (после мержа #21 GitHub сам переведёт базу на `main`).

## 1. Деплой стирал ежедневный дайджест

`update-news.yml` кладёт дайджест в `$DEPLOY_PATH/data/news.json`, а `deploy-vest-smr.yml` синхронизировал `dist/` с `--delete`. В `dist/` каталога `data/` нет, поэтому **каждый деплой сайта удалял `data/news.json`** — новости пропадали до следующего ночного запуска. Теперь и в workflow, и в документированной ручной команде стоит `--exclude=/data/`.

Дополнительно:

- `deploy/deploy.sh` — выкладка с рабочей машины, без ожидания секретов в репозитории: сборка, проверка `dist/index.html`, создание каталога `data/` на ВМ, rsync с тем же исключением.
- `deploy/README.md` — чек-лист в начале: настройка ВМ → DNS → загрузка файлов → HTTPS → секреты новостей, в том порядке, в котором это должно происходить. Отдельно отмечено, что автодеплой срабатывает только на `main`.

## 2. Бандл: главная тянула выгрузку салона

Сборка выдавала один чанк на 870 кБ (205 кБ gzip) и предупреждение Vite про размер:

- `Layout.tsx` (грузится на каждой странице) импортировал `fmtDate` из `lib/data`, а тот — `data/salon.json` на 388 кБ;
- все страницы импортировались статически, поэтому Recharts грузился даже там, где графиков нет.

Сделано:

- `src/lib/format.ts` — формат чисел и дат (`rub`, `num`, `fmtDate`, `monthLabel`, `pluralRu`, названия месяцев) без зависимостей от данных. `lib/data.ts` реэкспортит его, поэтому страницы салона не менялись; `Layout`, `AiDashboard`, `News`, `NewsDetail` берут `fmtDate` из `lib/format`.
- `App.tsx` — все маршруты через `lazy()` под общим `Suspense` с фолбэком «Загрузка…».
- nginx (`deploy/nginx-vest-smr.conf`, `salon-dashboard/nginx.container.conf`) — `index.html` с `Cache-Control: no-cache`: имена чанков меняются при деплое, и закешированный документ иначе запросит уже удалённые `/assets/*.js`.

| | до | после |
|---|---|---|
| стартовый чанк | 870 кБ / 205 кБ gzip | 220 кБ / 71 кБ gzip |
| `salon.json` | в стартовом чанке | отдельный чанк 227 кБ, только `/salon*` |
| Recharts | в стартовом чанке | отдельный чанк 337 кБ, только страницы с графиками |

## 3. CI для фронтенда

`.github/workflows/dashboard.yml` — на изменения в `salon-dashboard/**`: `npm ci`, `npm run lint`, `npm run build` и проверка, что стартовый чанк меньше 400 кБ. Раньше CI прогонял только линт и тесты Django, то есть сломанная сборка фронтенда доезжала до деплоя незамеченной; размер бандла — единственный сигнал, который поймает возврат `lib/data` или Recharts в постоянно загружаемый модуль.

`salon-dashboard/README.md` вместо шаблона Vite описывает структуру, команды, поток данных новостей, деплой и правило «в модулях, которые грузятся всегда, импортировать `lib/format`, а не `lib/data`».

## Проверено

- `npm run build` и `npm run lint` (oxlint) — чисто; Dashboard CI на этой ветке зелёный.
- Собранный `dist/` поднят локально и проверен в Chromium по всем 10 маршрутам: страницы рендерятся, без ошибок консоли и 4xx, фолбэк `Suspense` не залипает.
- По списку загруженных чанков подтверждено, что на `/` нет ни `data-*.js` (выгрузка салона), ни чанка Recharts, а на `/salon` они появляются.
- Проверка размера чанка из нового workflow прогнана локально: находит `index-*.js` из `index.html` и отдаёт 219 710 байт при лимите 400 000.
- `deploy/deploy.sh` проверен на синтаксис и на поведение без аргументов; сама выкладка не запускалась — доступа к ВМ из этой сессии нет.

`django.yml` запускается только для PR в `main`, поэтому его чеков здесь не будет, пока база не переключится на `main`.